### PR TITLE
Add LangFair to safety section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ This repository contains a curated list of 120+ LLM libraries category wise.
 | NeMo Guardrails | NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems. | [Link](https://github.com/NVIDIA/NeMo-Guardrails) |
 | Garak        | LLM vulnerability scanner | [Link](https://github.com/NVIDIA/garak) |
 | DeepTeam | The LLM Red Teaming Framework | [Link](https://github.com/confident-ai/deepteam)|
+| LangFair | Use-case-specific LLM bias/fairness assessments | [Link](https://github.com/cvs-health/langfair)|
 
 
 ## LLM Embedding Models


### PR DESCRIPTION
Add LangFair, an open-source toolkit for use-case-specific LLM bias/fairness assessments, to safety section. For more information on LangFair, see related links below:

* [LangFair repository](https://github.com/cvs-health/langfair)
* [LangFair software paper (Journal of Open Source Software)](https://joss.theoj.org/papers/10.21105/joss.07570)
* [LangFair research paper](https://arxiv.org/abs/2407.10853)