### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Join 🚀 [**AIxFunda** free newsletter](https://aixfunda.substack.com/) to get 
 | Phoenix            | An open-source AI observability platform designed for experimentation, evaluation, and troubleshooting. | [Link](https://github.com/Arize-ai/phoenix) |
 | Observers          | A Lightweight Library for AI Observability.                                                       | [Link](https://github.com/cfahlgren1/observers) |
 | traceAI            | Open-source OpenTelemetry-native tracing framework for LLM and AI agent applications. Auto-instruments 20+ frameworks (OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, Bedrock) capturing prompts, tokens, latency, and errors. | [Link](https://github.com/future-agi/traceAI) |
+| Future AGI | Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0. | [Link](https://github.com/future-agi/future-agi) |
 
 
 ## LLM Prompts


### PR DESCRIPTION
This PR adds Future AGI to this list in the **LLM Monitoring** section.

[ai-evaluation](https://github.com/future-agi/ai-evaluation) is Future AGI's open-source LLM/agent evaluation framework: 50+ metrics, LLM-as-Judge, multimodal and custom evals, and guardrail scanners.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.