### PR TITLE
Add StructEval evaluation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Join 🚀 [**AIxFunda** free newsletter](https://aixfunda.substack.com/) to get 
 | PydanticAI Evals | A powerful evaluation framework designed to help you systematically evaluate the performance of LLM applications. | [Link](https://ai.pydantic.dev/evals/) |
 | UQLM | A Python package for generation-time, zero-resource LLM hallucination using state-of-the-art uncertainty quantification techniques. | [Link](https://github.com/cvs-health/uqlm) |
 | ai-evaluation | Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge, guardrail scanners (jailbreak, PII, injection), and AutoEval pipelines with CI/CD support. | [Link](https://github.com/future-agi/ai-evaluation) |
+| StructEval | Benchmark and evaluation framework for LLM-generated structured outputs across 18 formats, with structural and visual evaluation. | [Link](https://github.com/TIGER-AI-Lab/StructEval) |
 
 
 


### PR DESCRIPTION
## What

- Adds StructEval to the LLM Evaluation table.
- Describes its coverage of 18 structured-output formats and structural and visual evaluation.

## Why

StructEval is a direct fit for the toolkit's evaluation and structured-output coverage: it provides an open-source benchmark and evaluation framework for renderable and non-renderable formats.

## Impact

Documentation only: one table row with the official repository link.

## Checks

- Verified the official repository link returns HTTP 200.
- Ran `git diff --check`.
- Confirmed the README contains one StructEval entry.

## Disclosure

I am a StructEval maintainer and am submitting this entry in that capacity. This contribution was prepared with assistance from OpenAI Codex.