### PR TITLE
Add OrcaReplay to LLM Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Join 🚀 [**AIxFunda** free newsletter](https://aixfunda.substack.com/) to get 
 | Weights & Biases (W&B) | W&B provides features for tracking LLM performance.                                          | [Link](https://github.com/wandb) |
 | Helicone            | Open source LLM-Observability Platform for Developers. One-line integration for monitoring, metrics, evals, agent tracing, prompt management, playground, etc. | [Link](https://github.com/Helicone/helicone) |
 | agenttrace          | Local-first TUI and CLI for monitoring AI coding-agent traces, costs, tokens, latency, and health regressions. | [Link](https://github.com/luoyuctl/agenttrace) |
+| OrcaReplay          | Records a coding-agent run below the harness so model traffic, shell exit codes, file changes and MCP calls share one timeline, then replays it offline or forks it onto another model. | [Link](https://github.com/Continuum-AI-Corp/OrcaReplay) |
 | Evidently          | An open-source ML and LLM observability framework.                                                | [Link](https://github.com/evidentlyai/evidently) |
 | Phoenix            | An open-source AI observability platform designed for experimentation, evaluation, and troubleshooting. | [Link](https://github.com/Arize-ai/phoenix) |
 | Observers          | A Lightweight Library for AI Observability.                                                       | [Link](https://github.com/cfahlgren1/observers) |


### PR DESCRIPTION
Adds OrcaReplay to **LLM Monitoring**.

The libraries there monitor a run; this one records and re-runs it. Capture happens at the process and socket boundary rather than through an SDK, so a coding-agent session's model traffic, shell commands with their exit codes, per-turn file changes and MCP calls all land on one timeline. Replay then serves the recorded responses back with the network off, reproducing the run byte-for-byte on any machine, and fork restarts it from a chosen checkpoint against a different model.

`agenttrace`, already in this table, is the nearest neighbour — it monitors coding-agent traces. Same audience; the difference is re-execution rather than inspection.

Row follows the table's three columns (Library / Description / Link). Apache-2.0, on npm as `orcareplay`, Node 20+, no SDK to integrate and no hosted backend.
