### PR TITLE
Add YYLO Benchmark to LLM Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Join 🚀 [**AIxFunda** free newsletter](https://aixfunda.substack.com/) to get 
 | UQLM | A Python package for generation-time, zero-resource LLM hallucination using state-of-the-art uncertainty quantification techniques. | [Link](https://github.com/cvs-health/uqlm) |
 | ai-evaluation | Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge, guardrail scanners (jailbreak, PII, injection), and AutoEval pipelines with CI/CD support. | [Link](https://github.com/future-agi/ai-evaluation) |
 | StructEval | Benchmark and evaluation framework for LLM-generated structured outputs across 18 formats, with structural and visual evaluation. | [Link](https://github.com/TIGER-AI-Lab/StructEval) |
+| YYLO Benchmark | Longitudinal evaluation and immutable evidence for agent runs: private fresh-repository workspaces, deterministic and LLM-judge evaluation profiles, and hash-linked receipts, manifests, and provenance. | [Link](https://github.com/yylo-dev/yylo-benchmark) |
 
 
 


### PR DESCRIPTION
## What

- Adds YYLO Benchmark to the LLM Evaluation table.
- Description phrases are taken verbatim from the project's README and repository description.

## Why

YYLO Benchmark is a direct fit for the toolkit's evaluation coverage: it is the evaluation layer for task prompts and project-owned Workflow Runner YAML, normalizing every case into one v2 attempt contract, running each candidate in a private fresh-repository workspace behind a selective filesystem sandbox, and evaluating retained evidence with ordered deterministic and/or LLM profiles. It complements the existing evaluation entries (Ragas, DeepEval, StructEval, AgentEvals) with the coding-agent evidence angle: hash-linked receipts, manifests, and provenance per attempt.

## Impact

Documentation only: one table row with the official repository link.

## Checks

- Verified the official repository link returns HTTP 200.
- Ran `git diff --check` (clean) — one file, +1/−0, appended at the section tail after StructEval (same shape as merged #33).
- Confirmed the README contains no prior YYLO entry (grep 0 before this PR).

## Disclosure

I am on the YYLO team and am submitting this entry in that capacity. This contribution was prepared with assistance from an AI coding agent. The benchmark repository is young on GitHub (1★, created 2026-08-17), so for adoption context: `@yylo/benchmark` has ~181 npm downloads/month, the parent `@yylo/cli` orchestrator has ~780 downloads/month and 57★ with daily pushes, both MIT.
